### PR TITLE
Update Minecraft Wiki link to new domain after fork

### DIFF
--- a/engines/wiki.py
+++ b/engines/wiki.py
@@ -27,7 +27,7 @@ def searcharchwiki(term, config):
 
 # This bit of code is cursed till I can figure out how to interpret it
 def searchmcwiki(term, config):
-    search_url = "https://minecraft.fandom.com/wiki/api.php?action=opensearch&export&search={}&limit=1".format(term.replace("-","_"))
+    search_url = "https://minecraft.wiki/w/api.php?action=opensearch&export&search={}&limit=1".format(term.replace("-","_"))
     search_data = requests.get(search_url).text
     
     print(search_data)


### PR DESCRIPTION
The Minecraft Wiki maintainers have decided to move away from Fandom. More information can be found here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all the URLs to the new domain: minecraft.wiki